### PR TITLE
Gradle configuration additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,26 @@ dependencies {
 **Avoid Maven dynamic dependency resolution**
 Avoid the use of dynamically versioned, such as `2.1.+` as this may result in different and unstable builds or subtle, untracked differences in behavior between builds. The use of static versions such as `2.1.1` helps create a more stable, predictable and repeatable development environment.
 
+**Use different package name for non-release builds**
+Use `applicationIdSuffix` for *debug* [build type](http://tools.android.com/tech-docs/new-build-system/user-guide#TOC-Build-Types) to be able to install both *debug* and *release* apk on the same device (do this also for custom build types, if you need any). This will be especially valuable later on in the app's lifecycle, after it has been published to the store.
+
+```groovy
+android {
+    buildTypes {
+        debug {
+            applicationIdSuffix '.debug'
+            versionNameSuffix '-DEBUG'
+        }
+
+        release {
+            // ...
+        }
+    }
+}
+```
+
+Use different icons to distinguish the builds installed on a device—for example with different colors or an overlaid  "debug" label. Gradle makes this very easy: with default project structure, simply put *debug* icon in `app/src/debug/res` and *release* icon in `app/src/release/res`. You could also [change app name](http://stackoverflow.com/questions/24785270/how-to-change-app-name-per-gradle-build-type) per build type, as well as  `versionName` (as in the above example).
+
 ### IDEs and text editors
 
 **Use whatever editor, but it must play nicely with the project structure.** Editors are a personal choice, and it's your responsibility to get your editor functioning according to the project structure and build system.

--- a/templates/rx-architecture/app/build.gradle
+++ b/templates/rx-architecture/app/build.gradle
@@ -73,6 +73,8 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
+            applicationIdSuffix '.debug'
+            versionNameSuffix '-DEBUG'
         }
         release {
             signingConfig signingConfigs.release


### PR DESCRIPTION
Use different package name for non-release builds

- Example of using `applicationIdSuffix` to be able to have debug & release apks installed on the same device. Based on [my answer](http://stackoverflow.com/a/21006552/56285) in [this Stack Overflow question](http://stackoverflow.com/questions/18491649/how-to-change-the-android-app-package-name-when-assembling-with-gradle). (As shown in that question, this can also be achieved with product flavors, but if you don't otherwise need flavors, it's an overkill for this purpose.)
