### PR TITLE
replace deprecated compile statement in gradle dependency examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ signingConfigs {
 
 ```groovy
 dependencies {
-    compile 'com.squareup.okhttp:okhttp3:3.8.0'
+    implementation 'com.squareup.okhttp:okhttp3:3.8.0'
 }
 ```    
 

--- a/translations/Chinese/README.cn.md
+++ b/translations/Chinese/README.cn.md
@@ -151,13 +151,13 @@ jar文件，那么它们可能成为固定的版本，如`2.1.1`.下载jar包更
 
 ```groovy
 dependencies {
-	compile 'com.netflix.rxjava:rxjava-core:0.19.+'
-	compile 'com.netflix.rxjava:rxjava-android:0.19.+'
-	compile 'com.fasterxml.jackson.core:jackson-databind:2.4.+'
-	compile 'com.fasterxml.jackson.core:jackson-core:2.4.+'
-	compile 'com.fasterxml.jackson.core:jackson-annotations:2.4.+'
-	compile 'com.squareup.okhttp:okhttp:2.0.+'
-	compile 'com.squareup.okhttp:okhttp-urlconnection:2.0.+'
+	implementation 'com.netflix.rxjava:rxjava-core:0.19.+'
+	implementation 'com.netflix.rxjava:rxjava-android:0.19.+'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.4.+'
+	implementation 'com.fasterxml.jackson.core:jackson-core:2.4.+'
+	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.4.+'
+	implementation 'com.squareup.okhttp:okhttp:2.0.+'
+	implementation 'com.squareup.okhttp:okhttp-urlconnection:2.0.+'
 }
 ```
 

--- a/translations/French/README.fr.md
+++ b/translations/French/README.fr.md
@@ -138,8 +138,8 @@ signingConfigs {
 
 ```groovy
 dependencies {
-    compile 'com.squareup.okhttp:okhttp:2.2.0'
-    compile 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
 }
 ```
 

--- a/translations/Japanese/README.ja.md
+++ b/translations/Japanese/README.ja.md
@@ -147,13 +147,13 @@ jarファイルをプロジェクトに直接includeしている場合、version
 
 ```groovy
 dependencies {
-    compile 'com.netflix.rxjava:rxjava-core:0.19.+'
-    compile 'com.netflix.rxjava:rxjava-android:0.19.+'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.4.+'
-    compile 'com.fasterxml.jackson.core:jackson-core:2.4.+'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.4.+'
-    compile 'com.squareup.okhttp:okhttp:2.0.+'
-    compile 'com.squareup.okhttp:okhttp-urlconnection:2.0.+'
+    implementation 'com.netflix.rxjava:rxjava-core:0.19.+'
+    implementation 'com.netflix.rxjava:rxjava-android:0.19.+'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.4.+'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.4.+'
+    implementation 'com.fasterxml.jackson.core:jackson-annotations:2.4.+'
+    implementation 'com.squareup.okhttp:okhttp:2.0.+'
+    implementation 'com.squareup.okhttp:okhttp-urlconnection:2.0.+'
 }
 ```
 

--- a/translations/Korean/README.ko.md
+++ b/translations/Korean/README.ko.md
@@ -138,8 +138,8 @@ signingConfigs {
 
 ```groovy
 dependencies {
-    compile 'com.squareup.okhttp:okhttp:2.2.0'
-    compile 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
 }
 ```
 

--- a/translations/Portuguese/README.pt.md
+++ b/translations/Portuguese/README.pt.md
@@ -138,8 +138,8 @@ signingConfigs {
 
 ```groovy
 dependencies {
-    compile 'com.squareup.okhttp:okhttp:2.2.0'
-    compile 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
 }
 ```    
 

--- a/translations/Russian/README.ru.md
+++ b/translations/Russian/README.ru.md
@@ -146,8 +146,8 @@ signingConfigs {
 
 ```groovy
 dependencies {
-    compile 'com.squareup.okhttp:okhttp:2.2.0'
-    compile 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
 }
 ```
 

--- a/translations/Spanish/README.es.md
+++ b/translations/Spanish/README.es.md
@@ -106,8 +106,8 @@ signingConfigs {
 
 ```groovy
 dependencies {
-    compile 'com.squareup.okhttp:okhttp:2.2.0'
-    compile 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
 }
 ```    
 

--- a/translations/Turkish/README.tr.md
+++ b/translations/Turkish/README.tr.md
@@ -140,8 +140,8 @@ signingConfigs {
 
 ```groovy
 dependencies {
-    compile 'com.squareup.okhttp:okhttp:2.2.0'
-    compile 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
 }
 ```    
 

--- a/translations/Vietnamese/README.vi.md
+++ b/translations/Vietnamese/README.vi.md
@@ -101,8 +101,8 @@ signingConfigs {
 
 ```groovy
 dependencies {
-    compile 'com.squareup.okhttp:okhttp:2.2.0'
-    compile 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp:2.2.0'
+    implementation 'com.squareup.okhttp:okhttp-urlconnection:2.2.0'
 }
 ```    
 


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation